### PR TITLE
Fix link pattern to include urls that hide preview

### DIFF
--- a/src/commands/chatgpt/chatgpt.ts
+++ b/src/commands/chatgpt/chatgpt.ts
@@ -18,7 +18,7 @@ export default class ChatGPT extends Command {
     private readonly model: string = process.env.DISCORD_BOT_OPENAI_MODEL || '';
     private readonly openAIClient?: OpenAI;
     private readonly instructions: string = '';
-    private readonly linkPattern: RegExp = /<?(https?:\/\/.+?)>?(\s|$)/gm;
+    private readonly linkPattern: RegExp = /<?(https?:\/\/.+?)>?(?:\s|$)/gm;
     private readonly processingQueue: ExecContext[] = [];
     private isProcessing: boolean = false;
 


### PR DESCRIPTION
Current issue:
[Urls preventing auto-embed](https://support.discord.com/hc/en-us/articles/206342858--How-do-I-disable-auto-embed) will not be parsed.

Solution:
This PR includes parsing urls which start with `<` and end with `>`.